### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,21 +15,16 @@ Please note, below in the dependencies you can also lock to a revision/tag in th
 
 `src-tauri/Cargo.toml`
 ```yaml
-[dependencies.tauri]
-git = "https://github.com/tauri-apps/tauri/"
-branch = "dev"
-features = ["api-all"]
+
 
 [dependencies.fix-path-env]
 git = "https://github.com/tauri-apps/fix-path-env-rs"
-tag = "fix-path-env-v0.1.0"
-#branch = "dev"
 ```
 
 Use in `src-tauri/src/main.rs`:
 ```rust
 fn main() {
-    fix_path_env::fix();
+    let _ = fix_path_env::fix();
     tauri::Builder::default()
         .run(tauri::generate_context!());
 }


### PR DESCRIPTION
 I am not sure if this is just me but:
- the previously stated git tag `fix-path-env-v0.1.0` in the ReadMe no longer exists, so it causes a breaking error.
- `[dependencies.tauri]` header is also not recognized, it causes a breaking error
- Also, the unnamed command in the `main.rs` also leads to some warnings.

For now, I have fixed it. It works for me, maybe it works for others too